### PR TITLE
Removed docs of obsolete option "use all device memory"

### DIFF
--- a/content/preferences-settings/processing.md
+++ b/content/preferences-settings/processing.md
@@ -80,9 +80,6 @@ OpenCL scheduling profile
 : - _very fast GPU_: both pixelpipes are processed sequentially on the GPU.
 : - _multiple GPUs_: both pixelpipes are processed in parallel on different GPUs -- see the [multiple devices](../special-topics/opencl/multiple-devices.md) section for more information.
 
-use all device memory
-: Enable this option to allow darktable to use all OpenCL memory on all devices except for a safety margin (headroom). The default headroom is 600MB and can also be specified on a per-device basis.
-
 OpenCL drivers
 : In most cases darktable is able to find the correct OpenCL driver but this depends on how your operating system handles installation. Generally speaking, darktable must:
 


### PR DESCRIPTION
See https://github.com/darktable-org/darktable/pull/18308

Thank you for taking the time to help the darktable documentation!

# Please include a link to the Pull Request that you are documenting

# Tell us a little bit about this pull request
